### PR TITLE
fix: match Worker name to the Workers Builds project

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,7 +2,7 @@
 # Md Takiuddin Ahmed — Senior Backend Engineer portfolio
 # Hono Worker (src/index.ts) serving static files via Workers Static Assets (./public).
 
-name = "takiuddinahmed-github-io"
+name = "takiuddin-portfolio"   # must match the Worker connected to Workers Builds
 main = "src/index.ts"
 compatibility_date = "2026-07-15"
 


### PR DESCRIPTION
Workers Builds is connected to the "takiuddin-portfolio" Worker, so set the same name in wrangler.toml to stop the CI name-mismatch override.