### PR TITLE
feat: add Prochesta to selected projects

### DIFF
--- a/profile/taki_details.md
+++ b/profile/taki_details.md
@@ -176,6 +176,26 @@ Polyglot microservices (Python + FastAPI, Node.js + NestJS, Go); PostgreSQL for 
 
 - Query optimisation (CTEs, indexes) reduced P95 contract-search latency from ~750 ms to well under 200 ms.
 
+## Prochesta – AI-Powered Exam-Preparation Platform
+(prochesta.app · CTO & Engineering Lead · EdTech SaaS for Bangladeshi competitive exams)
+
+#### Objective
+Help job seekers prepare for BCS, bank, and government-service exams through 1,200+ model tests, curated study materials, and a 24/7 AI study assistant — on web and Flutter mobile apps, with offline access — serving 50k+ learners.
+
+#### My role
+CTO & Engineering Lead: created the system architecture, review code across the team, and own the DevOps/CI-CD and deployment pipeline, observability, and performance.
+
+#### Architecture
+Node.js + Express API with MongoDB; Next.js dashboard front end; a Python + FastAPI AI service built on PydanticAI over PostgreSQL + pgvector for retrieval; Flutter mobile apps; containerised with Docker.
+
+#### Key contributions & impact
+
+- Designed the platform architecture spanning the Node.js API, Next.js dashboard, FastAPI AI service, and Flutter apps.
+
+- Built the CI/CD and deployment pipeline and added monitoring and distributed tracing for end-to-end observability.
+
+- Drove performance improvements across the API and the pgvector-backed AI retrieval path to keep the app responsive for 50k+ learners.
+
 ## Taxstar – UAE Corporate-Tax SaaS
 (Independent · Aug 2023 – Feb 2024 · FinTech micro-SaaS for SMB → enterprise)
 

--- a/public/index.html
+++ b/public/index.html
@@ -280,7 +280,7 @@
             "@id": "https://takiuddin.me/#projects-list",
             "name": "Selected projects by Md Takiuddin Ahmed",
             "itemListOrder": "https://schema.org/ItemListOrderDescending",
-            "numberOfItems": 4,
+            "numberOfItems": 5,
             "itemListElement": [
               {
                 "@type": "ListItem",
@@ -302,6 +302,21 @@
                 "position": 2,
                 "item": {
                   "@type": "SoftwareApplication",
+                  "name": "Prochesta",
+                  "url": "https://prochesta.app/",
+                  "applicationCategory": "EducationApplication",
+                  "applicationSubCategory": "Competitive Exam Preparation",
+                  "description": "AI-powered job- and civil-service-exam preparation platform (BCS, bank, government) with 1,200+ model tests, analytics, a Bangla AI study assistant, community, and offline-ready mobile apps for 50k+ learners.",
+                  "operatingSystem": "Web, Android",
+                  "creator": { "@id": "https://takiuddin.me/#person" },
+                  "softwareRequirements": "Node.js, Express, MongoDB, Next.js, Python, FastAPI, PostgreSQL, pgvector, Flutter, Docker"
+                }
+              },
+              {
+                "@type": "ListItem",
+                "position": 3,
+                "item": {
+                  "@type": "SoftwareApplication",
                   "name": "Taxstar",
                   "applicationCategory": "FinanceApplication",
                   "applicationSubCategory": "UAE Corporate Tax SaaS",
@@ -313,7 +328,7 @@
               },
               {
                 "@type": "ListItem",
-                "position": 3,
+                "position": 4,
                 "item": {
                   "@type": "SoftwareApplication",
                   "name": "Member Lounge",
@@ -327,7 +342,7 @@
               },
               {
                 "@type": "ListItem",
-                "position": 4,
+                "position": 5,
                 "item": {
                   "@type": "SoftwareApplication",
                   "name": "Honest Elite",
@@ -432,7 +447,7 @@
                 "name": "What are his most notable projects?",
                 "acceptedAnswer": {
                   "@type": "Answer",
-                  "text": "LambdaX (enterprise CLM at Cognitus), Taxstar (UAE corporate tax SaaS), Member Lounge (engagement suite with Stripe billing at Grype Digital), and Honest Elite (social network with WebRTC and Elasticsearch). Earlier projects also include work for the Bangladesh Navy, LearnGenie, and Devsfit."
+                  "text": "LambdaX (enterprise CLM at Cognitus), Prochesta (AI-powered exam-prep platform where he is CTO & Engineering Lead), Taxstar (UAE corporate tax SaaS), Member Lounge (engagement suite with Stripe billing at Grype Digital), and Honest Elite (social network with WebRTC and Elasticsearch). Earlier projects also include work for the Bangladesh Navy, LearnGenie, and Devsfit."
                 }
               },
               {
@@ -1672,6 +1687,26 @@
 
             <article class="project">
               <div class="project-head">
+                <span class="dir">~/projects</span><span class="slash">/</span><span>prochesta</span>
+              </div>
+              <h3 class="project-name">Prochesta &mdash; AI Exam-Prep Platform</h3>
+              <p class="project-desc">
+                Bangladesh&rsquo;s leading job-exam prep platform (BCS, bank, government) &mdash; model
+                tests with analytics, a Bangla AI study assistant, and offline-ready Flutter apps for
+                50k+ learners. As CTO I own the architecture, CI/CD and deployment, observability, and performance.
+              </p>
+              <div class="project-stack">
+                <span class="chip">Node.js</span>
+                <span class="chip">MongoDB</span>
+                <span class="chip">Next.js</span>
+                <span class="chip">FastAPI</span>
+                <span class="chip">pgvector</span>
+                <span class="chip">Flutter</span>
+              </div>
+            </article>
+
+            <article class="project">
+              <div class="project-head">
                 <span class="dir">~/projects</span><span class="slash">/</span><span>taxstar</span>
               </div>
               <h3 class="project-name">Taxstar &mdash; UAE Corporate Tax SaaS</h3>
@@ -1933,8 +1968,10 @@
             <details class="faq-item">
               <summary>What are his most notable projects?</summary>
               <p class="faq-answer">
-                LambdaX (enterprise CLM at Cognitus), Taxstar (UAE corporate-tax
-                SaaS), Member Lounge (engagement suite with Stripe billing at
+                LambdaX (enterprise CLM at Cognitus), Prochesta (AI-powered
+                exam-prep platform where he is CTO &amp; Engineering Lead),
+                Taxstar (UAE corporate-tax SaaS), Member Lounge (engagement
+                suite with Stripe billing at
                 Grype Digital), and Honest Elite (social network with WebRTC and
                 Elasticsearch). Earlier projects also include work for the
                 Bangladesh Navy, LearnGenie, and Devsfit.

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -83,6 +83,11 @@ Enterprise contract-lifecycle-management platform replacing scattered, email-dri
 Role: Core back-end engineer.
 Stack: Python, FastAPI, Go, Rust, PostgreSQL, Kafka, Redis, Kubernetes.
 
+### Prochesta — AI Exam-Prep Platform
+Bangladesh's leading job- and civil-service-exam preparation platform (BCS, bank, government) with 1,200+ model tests and analytics, 10k+ study materials, a Bangla AI study assistant (voice and image input), a community forum, offline access, and Flutter mobile apps serving 50k+ learners.
+Role: CTO & Engineering Lead — designed the architecture, review code, own the CI/CD and deployment pipeline, added monitoring and distributed tracing, and drive performance improvements.
+Stack: Node.js, Express, MongoDB, Next.js (dashboard), Python, FastAPI + PydanticAI (AI), PostgreSQL, pgvector, Flutter, Docker.
+
 ### Taxstar — UAE Corporate Tax SaaS
 Multi-tenant fintech SaaS helping UAE businesses comply with federal corporate tax through a rules-driven calculation engine, forecasting, and deadline reminders.
 Stack: Python, Flask, MongoDB, Docker, Kubernetes.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -31,6 +31,7 @@ Last updated: 2026-05-02.
 ## Selected projects
 
 - LambdaX — enterprise contract-lifecycle-management platform (Python, FastAPI, Go, PostgreSQL, Kafka, Kubernetes).
+- Prochesta — AI-powered job- and civil-service-exam prep platform (BCS, bank, government) with model tests, analytics, a Bangla AI assistant, and Flutter mobile apps; CTO & Engineering Lead (Node.js, Express, MongoDB, Next.js, FastAPI, PostgreSQL, pgvector, Flutter, Docker).
 - Taxstar — UAE corporate-tax SaaS (Python, Flask, MongoDB, Docker, Kubernetes).
 - Member Lounge — engagement SaaS with Stripe billing and notification fan-out (NestJS, MongoDB, RabbitMQ, Stripe, Next.js).
 - Honest Elite — niche social network with WebRTC calls and Elasticsearch feed (NestJS, GraphQL, MongoDB, WebRTC, Elasticsearch).


### PR DESCRIPTION
## Summary

Adds **Prochesta** — an AI-powered exam-prep platform (BCS / bank / government exams) where Taki is CTO & Engineering Lead — as the second entry in Selected projects, kept consistent across every surface the site keeps in sync.

## Changes

- **Visible card** (`public/index.html`): new `~/projects/prochesta` card with the CTO role and stack chips (Node.js · MongoDB · Next.js · FastAPI · pgvector · Flutter)
- **JSON-LD `@graph`**: new `SoftwareApplication` at position 2; existing projects renumbered; `numberOfItems` 4 → 5
- **FAQ** (page + schema): "most notable projects" answer now includes Prochesta
- **AI surfaces**: `public/llms.txt`, `public/llms-full.txt`
- **Long-form source**: `profile/taki_details.md`

## Notes

- Base is `migrate-to-hono-worker` so the diff shows **only** the Prochesta change (GitHub auto-retargets to `main` once that branch merges).
- Added as a project only — the experience timeline and bio headline are untouched.

Verified: the JSON-LD parses and lists `1:LambdaX, 2:Prochesta, 3:Taxstar, 4:Member Lounge, 5:Honest Elite`.
