### PR TITLE
fix: 301 legacy ?q= search URLs to the canonical homepage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,9 +64,20 @@ app.post('/hello', async (c) => {
 //    and SEO headers (ported from the old `_headers` per-type blocks). ETag/304 handling
 //    and content negotiation are provided automatically by Workers Static Assets.
 app.all('*', async (c) => {
+  const url = new URL(c.req.url)
+  const p = url.pathname
+
+  // Legacy Sitelinks-Searchbox artifact: an old SearchAction advertised
+  // /?q={search_term_string}. The site has no search, so 301 any ?q= on the
+  // homepage to the canonical URL — this removes the duplicate Google filed as
+  // "Alternate page with proper canonical tag". Scoped to `q` only so analytics
+  // params (utm_*, gclid, fbclid) are never stripped.
+  if ((p === '/' || p === '/index.html') && url.searchParams.has('q')) {
+    return c.redirect('https://takiuddin.me/', 301)
+  }
+
   const res = await c.env.ASSETS.fetch(c.req.raw)
   const h = new Headers(res.headers)
-  const p = new URL(c.req.url).pathname
 
   if (p.startsWith('/assets/')) {
     h.set('Cache-Control', 'public, max-age=31536000, s-maxage=31536000, immutable')


### PR DESCRIPTION
## Summary

Fixes the Google Search Console failure for `https://takiuddin.me/?q={search_term_string}` — flagged under **"Alternate page with proper canonical tag."**

That URL was advertised by an old Schema.org **SearchAction** (Sitelinks Searchbox) whose `urlTemplate` was `https://takiuddin.me/?q={search_term_string}`. The markup is **already gone** (removed during the Hono migration), but the URL Google discovered still returns `200` (it just serves the homepage), so it stays parked as a canonicalized duplicate and the validation never clears.

The site has no search feature, so this adds a `301` from any `?q=` request on the homepage to the canonical URL — a stronger signal than the canonical tag alone, letting Google drop the duplicate.

## Change

`src/index.ts` — early return at the top of the catch-all:

```ts
if ((p === '/' || p === '/index.html') && url.searchParams.has('q')) {
  return c.redirect('https://takiuddin.me/', 301)
}
```

- Scoped to the `q` param, so `utm_*` / `gclid` / `fbclid` links are **not** redirected — Google Analytics campaign attribution is unaffected.
- Fires regardless of the value, so it also catches the literal `?q={search_term_string}` on recrawl.
- The 301 flows through the existing security-headers middleware (same path the `/github`, `/cv`, … redirects use), so `Location` + HSTS/CSP are preserved.

No changes to `robots.txt` (keeping the URL crawlable is what lets Google *see* the redirect), JSON-LD, sitemap, or HTML.

## Verification (local `wrangler dev`)

| Request | Result |
|---|---|
| `/?q=test` | **301** → `https://takiuddin.me/` |
| `/?q=%7Bsearch_term_string%7D` | **301** → `https://takiuddin.me/` |
| `/index.html?q=x` | **301** → `https://takiuddin.me/` |
| `/?utm_source=x` | **200** (not redirected) |
| `/` | **200** |

`npm run typecheck` passes.

## After merge

Deploy (`npm run deploy`), confirm `curl -I "https://takiuddin.me/?q={search_term_string}"` returns `301`, then in Search Console open the report → **Validate Fix** (recrawl takes a few days).
