### PR TITLE
chore: replace theme boilerplate with a real license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Md Takiuddin Ahmed
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/public/license.txt
+++ b/public/license.txt
@@ -1,29 +1,47 @@
-Bootstrap 5 Portfolio Theme for Developers
-
-Theme name:
+License — takiuddin.me
 =======================================================================
-Developer 
 
-Theme version:
+Copyright (c) 2026 Md Takiuddin Ahmed. All rights reserved.
+
+This website (takiuddin.me) has two parts under two different licenses:
+the source code and the personal content. Where they overlap, the
+content terms below govern the content.
+
+
+Source code
 =======================================================================
-Bootstrap 5 v2.0
+The source code of this site — the Cloudflare Worker (src/), build and
+image scripts, configuration, and the HTML/CSS/JavaScript markup that
+makes up the pages — is released under the MIT License. You may reuse,
+modify, and redistribute the code under those terms. The full text is in
+the LICENSE file at the root of the repository:
 
-Release Date:
+    https://github.com/takiuddinahmed/takiuddinahmed.github.io/blob/main/LICENSE
+
+
+Personal content — All Rights Reserved
 =======================================================================
-2022-06-08
+The personal content of this site is NOT covered by the MIT License and
+is protected by copyright. This includes, without limitation:
 
-Author: 
+  - Written text: biography, "about" copy, project and experience
+    descriptions, FAQ answers, and other prose
+  - The resume / CV (including the PDF at /assets/files/) and its layout
+  - Photographs, portraits, logos, and other images
+  - The name, likeness, and personal branding of Md Takiuddin Ahmed
+
+You may view this content in your browser and link to it. You may NOT
+copy, reproduce, republish, redistribute, adapt, or use it to represent
+yourself or any other person, and you may NOT use it to train machine-
+learning models, without prior written permission.
+
+Brief quotation for commentary, review, or news reporting, with clear
+attribution, is permitted under normal fair-use principles.
+
+
+Contact
 =======================================================================
-Xiaoying Riley at 3rd Wave Media (https://themes.3rdwavemedia.com/)
+For licensing requests or permissions beyond the above:
 
-Contact:
-=======================================================================
-Web: https://themes.3rdwavemedia.com/
-Email: themes@3rdwavemedia.com
-Twitter: @3rdwave_themes
-
-License: 
-=======================================================================
-This template is 100% FREE as long as you keep the footer attribution link. You do not have the rights to resell, sublicense or redistribute (even for free) the template on its own or as a separate attachment from any of your work.
-
-If you’d like to use this template without the footer attribution link, you can buy the commercial license - https://themes.3rdwavemedia.com/bootstrap-templates/resume/free-bootstrap-theme-for-web-developers/
+    Web:   https://takiuddin.me
+    Email: takiuddinahmed@gmail.com


### PR DESCRIPTION
## What

The served `public/license.txt` was leftover boilerplate from the original Bootstrap theme (Xiaoying Riley / 3rd Wave Media) and no longer describes this site — it was rewritten long ago as a self-contained Hono Worker with hand-written HTML/CSS/JS.

## Changes

- **Add `LICENSE`** (repo root) — standard, verbatim MIT License covering the **source code** (`© 2026 Md Takiuddin Ahmed`). Kept as pristine MIT text so GitHub license detection recognizes it.
- **Rewrite `public/license.txt`** as the real license, split in two:
  - **Source code** → MIT, pointing at the root `LICENSE`.
  - **Personal content** (bio, project/FAQ prose, resume/CV + PDF, photos, name/branding) → **All Rights Reserved**, with a no-copy / no-ML-training clause and a fair-use quotation carve-out.

## Notes

- The JSON-LD `license` reference in `index.html` already points at `https://takiuddin.me/license.txt`; it now resolves to accurate content terms (no change needed there).
- `LICENSE` sits at the repo root, so it's visible on GitHub but **not** served by the Worker (only `public/` is served) — correct, since the served, JSON-LD-cited file is `license.txt`.
- Contact email in `license.txt` matches the public `mailto:` in the site's JSON-LD (`takiuddinahmed@gmail.com`).
- No code, build, or deploy changes.