### PR TITLE
seo: noindex utility files so they stay out of search results

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,9 @@ app.post('/hello', async (c) => {
   return c.json({ ok: true, message: "Thanks for reaching out, I'll be in touch soon.", received })
 })
 
+// Machine-readable / utility files kept out of search results (applied in the catch-all).
+const NOINDEX_PATHS = new Set(['/robots.txt', '/sitemap.xml', '/manifest.json', '/license.txt', '/404.html'])
+
 // 4) Catch-all: serve static assets, layering per-path Cache-Control, Content-Type,
 //    and SEO headers (ported from the old `_headers` per-type blocks). ETag/304 handling
 //    and content negotiation are provided automatically by Workers Static Assets.
@@ -81,10 +84,13 @@ app.all('*', async (c) => {
 
   if (p === '/manifest.json') h.set('Content-Type', 'application/manifest+json')
   if (p === '/sitemap.xml') h.set('Content-Type', 'application/xml')
-  if (p === '/robots.txt') {
-    h.set('Content-Type', 'text/plain; charset=utf-8')
-    h.set('X-Robots-Tag', 'noindex')
-  }
+  if (p === '/robots.txt' || p === '/license.txt') h.set('Content-Type', 'text/plain; charset=utf-8')
+
+  // Utility / machine-readable files: keep the URLs out of search *results*.
+  // noindex only suppresses the file as a result — Google still reads
+  // robots.txt and sitemap.xml normally for crawling and discovery.
+  if (NOINDEX_PATHS.has(p)) h.set('X-Robots-Tag', 'noindex')
+
   if (p === '/llms.txt' || p === '/llms-full.txt') {
     h.set('Content-Type', 'text/plain; charset=utf-8')
     h.set('Access-Control-Allow-Origin', '*')


### PR DESCRIPTION
## Why

Google Search Console flagged `/license.txt` and the `/image` redirect under **"Crawled – currently not indexed."** That's expected — neither belongs in the search index — but it leaves them in an ambiguous bucket. Marking the machine-readable/utility files as `noindex` states the intent explicitly and moves them to the cleaner **"Excluded by 'noindex' tag"** state.

## Change

In the `src/index.ts` catch-all, send `X-Robots-Tag: noindex` for a small set of utility files:

| Path | Before | After |
|------|--------|-------|
| `/robots.txt` | noindex | noindex (unchanged) |
| `/sitemap.xml` | — | **noindex** |
| `/manifest.json` | — | **noindex** |
| `/license.txt` | — | **noindex** |
| `/404.html` | — | **noindex** (served `200` if hit directly) |

`noindex` only suppresses the URL as a *search result* — Google still fetches `robots.txt` and `sitemap.xml` normally for crawling and discovery.

## Untouched (intentionally indexable)

`/`, `llms.txt`, `llms-full.txt`, the resume PDF (`index, follow, max-snippet:-1`), and image assets (e.g. `profile.jpg`, which is in the image sitemap).

## Notes

- `/image` is a **301 redirect** to `/assets/images/profile.jpg` — you can't `noindex` a redirect; GSC will settle it into **"Page with redirect"** on its own.
- Independent of #15 (that PR rewrites the license *content*; this one only adds a response header). No file overlap — merge in any order.
- `typecheck` passes. No behavior change to the served bodies.