### PR TITLE
fix: 301 legacy ?q= search URLs to the canonical homepage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,9 +64,20 @@ app.post('/hello', async (c) => {
 //    and SEO headers (ported from the old `_headers` per-type blocks). ETag/304 handling
 //    and content negotiation are provided automatically by Workers Static Assets.
 app.all('*', async (c) => {
+  const url = new URL(c.req.url)
+  const p = url.pathname
+
+  // Legacy Sitelinks-Searchbox artifact: an old SearchAction advertised
+  // /?q={search_term_string}. The site has no search, so 301 any ?q= on the
+  // homepage to the canonical URL — this removes the duplicate Google filed as
+  // "Alternate page with proper canonical tag". Scoped to `q` only so analytics
+  // params (utm_*, gclid, fbclid) are never stripped.
+  if ((p === '/' || p === '/index.html') && url.searchParams.has('q')) {
+    return c.redirect('https://takiuddin.me/', 301)
+  }
+
   const res = await c.env.ASSETS.fetch(c.req.raw)
   const h = new Headers(res.headers)
-  const p = new URL(c.req.url).pathname
 
   if (p.startsWith('/assets/')) {
     h.set('Cache-Control', 'public, max-age=31536000, s-maxage=31536000, immutable')


### PR DESCRIPTION
## Why

Google discovered `/?q={search_term_string}` from an old Sitelinks-Searchbox `SearchAction` (since removed) and files it under **"Alternate page with proper canonical tag."** The homepage has no search, so these `?q=` URLs are pure duplicates.

## Change

In the `src/index.ts` catch-all, 301-redirect any `?q=` request on `/` (or `/index.html`) to the canonical `https://takiuddin.me/`, so Google drops the duplicate. Scoped to the `q` param only, so analytics params (`utm_*`, `gclid`, `fbclid`) are never stripped.

```ts
if ((p === '/' || p === '/index.html') && url.searchParams.has('q')) {
  return c.redirect('https://takiuddin.me/', 301)
}
```

## Context

This fix originally shipped in #14, but that PR merged into `migrate-to-hono-worker` rather than `main`, so it never reached the live `main`. The original branch (`fix/seo-search-query-redirect`) is now stale (predates the #15 LICENSE merge), so this is a clean cherry-pick of just that one commit onto current `main` — no other files touched.

## Notes

- `typecheck` passes.
- Minor, expected: overlaps the same `app.all('*')` region as #16, so whichever merges second may need a one-line rebase.