### PR TITLE
fix: copyable contact curl breaks when pasted into a shell

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2053,8 +2053,8 @@
             <div class="cmd-block" aria-label="Example command to get in touch">
               <p class="line"><span style="color:var(--text-muted)"># say hello &mdash; message required; name, phone, email optional</span></p>
               <p class="line"><span class="cmd">curl</span> <span class="flag">-X</span> POST <span class="arg">https://takiuddin.me/hello</span> \</p>
-              <p class="line">&nbsp;&nbsp;<span class="flag">-H</span> <span class="arg">'Content-Type: application/json'</span> \</p>
-              <p class="line">&nbsp;&nbsp;<span class="flag">-d</span> <span class="arg">'{"message":"let us build something","name":"Jane Doe","email":"jane@acme.com"}'</span></p>
+              <p class="line">  <span class="flag">-H</span> <span class="arg">'Content-Type: application/json'</span> \</p>
+              <p class="line">  <span class="flag">-d</span> <span class="arg">'{"message":"let us build something","name":"Jane Doe","email":"jane@acme.com"}'</span></p>
               <p class="line" style="margin-top:10px"><span style="color:var(--text-muted)"># simply:</span></p>
               <p class="line"><span class="cmd">mailto</span>:<a href="mailto:takiuddinahmed@gmail.com">takiuddinahmed@gmail.com</a></p>
             </div>


### PR DESCRIPTION
## Problem

Copying the `curl` command from the contact section and pasting it into a shell returned:

```
{"ok":false,"error":"Body must be valid JSON."}
```

The `/hello` endpoint itself is fine — a clean request returns `{"ok":true,...}`.

## Root cause

The `-H` and `-d` lines in the snippet were indented with `&nbsp;&nbsp;` (U+00A0 non-breaking spaces). Copying the command carried those literal U+00A0 bytes into the shell. Bash doesn't treat U+00A0 as a word separator, so after each `\` line-continuation the flags became `\xa0\xa0-H` / `\xa0\xa0-d`. curl no longer recognized them as flags and parsed them (and their quoted values) as additional URLs — you'd see `curl: (6) Could not resolve host:   -h`. The net effect was a **bodyless** `POST /hello`, so the server correctly reported invalid JSON.

## Fix

Use plain ASCII spaces for the indentation. The rendered snippet is visually unchanged because `.cmd-block .line` is `white-space: pre-wrap`, but the command now copies as valid shell.

## Verification

- Clean request → `{"ok":true,...}` ✓
- Reproduced the failure byte-for-byte with U+00A0 indentation → the reported error ✓
- After the fix, copied text contains only ASCII spaces ✓